### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+    contents: read
 
 on:
     push:


### PR DESCRIPTION
Potential fix for [https://github.com/qdequippe-tech/yousign-php-api/security/code-scanning/3](https://github.com/qdequippe-tech/yousign-php-api/security/code-scanning/3)

In general, to fix this problem you should explicitly declare a `permissions` block for the workflow and/or each job so that the `GITHUB_TOKEN` has only the privileges required to run. For read-only CI tasks that just check out the code and run analysis, `contents: read` is typically sufficient.

For this specific workflow, the `check-cs` job only checks out the repository and runs PHP-CS-Fixer in dry-run mode, so it does not need any write permissions. The simplest and least-intrusive fix is to add a workflow-level `permissions` block (applies to all jobs) near the top of `.github/workflows/ci.yml`, right after the `name: CI` line. Set `contents: read` as the minimal starting point recommended by CodeQL. No imports or additional methods are needed since this is just a YAML configuration change.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert a `permissions:` section after line 1 (`name: CI`) with `contents: read`.
- Leave the rest of the workflow unchanged so functionality remains identical, but with a restricted `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
