### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/diff-spec.yml
+++ b/.github/workflows/diff-spec.yml
@@ -9,6 +9,9 @@ jobs:
     check-spec:
         name: Check SDK is in sync with spec
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
         steps:
             - name: Checkout
               uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/qdequippe-tech/yousign-php-api/security/code-scanning/4](https://github.com/qdequippe-tech/yousign-php-api/security/code-scanning/4)

In general, to fix this issue you explicitly declare a `permissions` block either at the workflow root (applies to all jobs) or at the job level, and grant only the minimum scopes required. For this workflow, the main sensitive operation is the `Create Pull Request` step using `peter-evans/create-pull-request@v8`. According to the action’s documentation and GitHub’s permission model, it needs `contents: write` to push branches/commits and `pull-requests: write` to open/update PRs. The earlier steps (checkout, dependency install, code generation, formatting) only need read access to repository contents.

The minimal, non-breaking change is to add a `permissions` block under the `check-spec` job, at the same indentation level as `name` and `runs-on`. That way, we don’t affect any other workflows and we ensure this job has exactly the needed permissions. Concretely, in `.github/workflows/diff-spec.yml`, after line 11 (`runs-on: ubuntu-latest`), insert:

```yaml
        permissions:
            contents: write
            pull-requests: write
```

No imports or additional methods are needed because this is pure YAML configuration. Existing functionality is preserved: the job can still push generated changes and create/update pull requests, while no broader permissions are implicitly granted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
